### PR TITLE
[BACK-1271] Fix export for pump types that have plural pumpSettings

### DIFF
--- a/app.js
+++ b/app.js
@@ -99,6 +99,7 @@ app.get('/export/:userid', async (req, res) => {
 
       dataResponse.data
         .pipe(dataTools.jsonParser())
+        .pipe(dataTools.splitPumpSettingsData())
         .pipe(dataTools.tidepoolProcessor(processorConfig))
         .pipe(dataTools.jsonStreamWriter())
         .pipe(res);
@@ -107,6 +108,7 @@ app.get('/export/:userid', async (req, res) => {
 
       dataResponse.data
         .pipe(dataTools.jsonParser())
+        .pipe(dataTools.splitPumpSettingsData())
         .pipe(dataTools.tidepoolProcessor(processorConfig))
         .pipe(dataTools.xlsxStreamWriter(res, processorConfig));
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/export",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "main": "app.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION

* Forgot to add an extra pipeline stage in the export service
  that was fixed and working in `@tidepool/data-tools` v2.3.1