### PR TITLE
Add prometheus metrics to export

### DIFF
--- a/app.js
+++ b/app.js
@@ -165,12 +165,12 @@ app.get('/export/:userid', async (req, res) => {
     clearTimeout(timer);
   } catch (error) {
     if (error.response && error.response.status === 403) {
-      res.status(error.response.status).send('Not authorized to export data for this user.');
       statusCount.inc({ status_code: 403 });
+      res.status(error.response.status).send('Not authorized to export data for this user.');
       log.error(`${error.response.status}: ${error}`);
     } else {
-      res.status(500).send('Server error while processing data. Please contact Tidepool Support.');
       statusCount.inc({ status_code: 500 });
+      res.status(500).send('Server error while processing data. Please contact Tidepool Support.');
       log.error(`500: ${error}`);
     }
   }

--- a/app.js
+++ b/app.js
@@ -114,7 +114,9 @@ app.get('/export/:userid', async (req, res) => {
 
     let writeStream = null;
 
-    if (req.query.format === 'json') {
+    const exportFormat = req.query.format;
+
+    if (exportFormat === 'json') {
       res.attachment('TidepoolExport.json');
       writeStream = dataTools.jsonStreamWriter();
 
@@ -148,11 +150,11 @@ app.get('/export/:userid', async (req, res) => {
         dataResponse.data.on('error', (err) => reject(err));
         res.on('error', (err) => reject(err));
         res.on('timeout', async () => {
-          statusCount.inc({ status_code: 408, export_format: req.query.format });
+          statusCount.inc({ status_code: 408, export_format: exportFormat });
           reject(new Error('Data export request took too long to complete. Cancelling the request.'));
         });
       });
-      statusCount.inc({ status_code: 200, export_format: req.query.format });
+      statusCount.inc({ status_code: 200, export_format: exportFormat });
       log.debug(`Finished downloading data for User ${req.params.userid}`);
     } catch (e) {
       log.error(`Error while downloading: ${e}`);
@@ -165,11 +167,11 @@ app.get('/export/:userid', async (req, res) => {
     clearTimeout(timer);
   } catch (error) {
     if (error.response && error.response.status === 403) {
-      statusCount.inc({ status_code: 403, export_format: req.query.format });
+      statusCount.inc({ status_code: 403, export_format: exportFormat });
       res.status(error.response.status).send('Not authorized to export data for this user.');
       log.error(`${error.response.status}: ${error}`);
     } else {
-      statusCount.inc({ status_code: 500, export_format: req.query.format });
+      statusCount.inc({ status_code: 500, export_format: exportFormat });
       res.status(500).send('Server error while processing data. Please contact Tidepool Support.');
       log.error(`500: ${error}`);
     }

--- a/app.js
+++ b/app.js
@@ -27,7 +27,7 @@ const createCounter = (name, help, labelNames) => new Counter({
   name, help, labelNames, registers: [register],
 });
 
-const statusCount = createCounter('tidepool_export_failed_status_count', 'The number of errors for each status code.', ['status_code']);
+const statusCount = createCounter('tidepool_export_status_count', 'The number of errors for each status code.', ['status_code']);
 
 function maybeReplaceWithContentsOfFile(obj, field) {
   const potentialFile = obj[field];

--- a/app.js
+++ b/app.js
@@ -101,6 +101,8 @@ app.get('/export/:userid', async (req, res) => {
   }
   log.info(logString);
 
+  const exportFormat = req.query.format;
+
   try {
     const cancelRequest = axios.CancelToken.source();
 
@@ -113,8 +115,6 @@ app.get('/export/:userid', async (req, res) => {
     const processorConfig = { bgUnits: req.query.bgUnits || 'mmol/L' };
 
     let writeStream = null;
-
-    const exportFormat = req.query.format;
 
     if (exportFormat === 'json') {
       res.attachment('TidepoolExport.json');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/export",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "main": "app.js",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "esm": "3.2.25",
     "express": "4.17.1",
     "lodash": "4.17.15",
+    "prom-client": "^12.0.0",
     "query-string": "6.13.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -372,6 +372,11 @@ binary@~0.3.0:
     buffers "~0.1.1"
     chainsaw "~0.1.0"
 
+bintrees@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/bintrees/-/bintrees-1.0.1.tgz#0e655c9b9c2435eaab68bf4027226d2b55a34524"
+  integrity sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ=
+
 bl@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/bl/-/bl-3.0.0.tgz#3611ec00579fd18561754360b21e9f784500ff88"
@@ -2107,6 +2112,13 @@ progress@^2.0.0:
   resolved "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
+prom-client@^12.0.0:
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-12.0.0.tgz#9689379b19bd3f6ab88a9866124db9da3d76c6ed"
+  integrity sha512-JbzzHnw0VDwCvoqf8y1WDtq4wSBAbthMB1pcVI/0lzdqHGJI3KBJDXle70XK+c7Iv93Gihqo0a5LlOn+g8+DrQ==
+  dependencies:
+    tdigest "^0.1.1"
+
 prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
@@ -2628,6 +2640,13 @@ tar-stream@^2.1.0:
     fs-constants "^1.0.0"
     inherits "^2.0.3"
     readable-stream "^3.1.1"
+
+tdigest@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/tdigest/-/tdigest-0.1.1.tgz#2e3cb2c39ea449e55d1e6cd91117accca4588021"
+  integrity sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=
+  dependencies:
+    bintrees "1.0.1"
 
 text-table@^0.2.0:
   version "0.2.0"


### PR DESCRIPTION
Added a status counter for the various outcomes of an export. Got any more suggestions on what metrics to add? @pazaan The key statuses to track here are timeouts(408) and internal server errors (500) labeled with export format. Preview: https://grafana.qa2.tidepool.org/d/HNqFvjVGk/tidepool-services-export?orgId=1&from=1596473545176&to=1596474699503