### PR TITLE
[BACK-2685] always fetch latest settings for date bound reports

### DIFF
--- a/lib/report.js
+++ b/lib/report.js
@@ -249,11 +249,12 @@ class Report {
   }
 
   buildReportQueries({ data }) {
+    const bgSource = _.get(data, 'metaData.bgSources.current');
     const dataQueries = {
       basics: {
         endpoints: [],
         aggregationsByDate: 'basals, boluses, fingersticks, siteChanges',
-        bgSource: 'cbg',
+        bgSource: bgSource || 'cbg',
         stats: this.getStatsByChartType('basics', data),
         excludeDaysWithoutBolus: false,
         bgPrefs: this.getBGPrefs(),
@@ -288,7 +289,7 @@ class Report {
           smbg: {},
           wizard: {},
         },
-        bgSource: 'cbg',
+        bgSource: bgSource || 'cbg',
         bgPrefs: this.getBGPrefs(),
         metaData: 'latestPumpUpload, bgSources',
         timePrefs: this.getTimePrefs(),

--- a/lib/report.js
+++ b/lib/report.js
@@ -720,6 +720,41 @@ class Report {
       if (pumpSettingsFetch?.length > 0) {
         userData.push(pumpSettingsFetch[0]);
       }
+
+      const latestPumpSettings = find(userData, {
+        type: 'pumpSettings',
+      });
+
+      const latestPumpSettingsUploadId = get(
+        latestPumpSettings || {},
+        'uploadId',
+      );
+
+      const latestPumpSettingsUpload = find(userData, {
+        type: 'upload',
+        uploadId: latestPumpSettingsUploadId,
+      });
+
+      if (latestPumpSettingsUploadId && !latestPumpSettingsUpload) {
+        // If we have pump settings, but we don't have the corresponing upload record used
+        // to get the device source, we need to fetch it
+        const pumpSettingsUploadFetch = await fetchUserData(
+          this.#userDetail.userId,
+          {
+            headers: this.#requestData.sessionHeader,
+            params: {
+              type: 'upload',
+              uploadId: latestPumpSettingsUploadId,
+            },
+          },
+        ).catch((error) => {
+          this.#log.error(error);
+        });
+
+        if (pumpSettingsUploadFetch?.length > 0) {
+          userData.push(pumpSettingsUploadFetch[0]);
+        }
+      }
     }
 
     this.#log.debug(`Downloading data for User ${this.#userDetail.userId}...`);

--- a/lib/report.js
+++ b/lib/report.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-expressions */
 import getAGPFigures from '@tidepool/viz/dist/getAGPFigures.js';
 import vizDataUtil from '@tidepool/viz/dist/data.js';
 import { Blob } from 'buffer';
@@ -49,6 +50,22 @@ class Report {
     agp: 'agp',
     daily: 'daily',
     settings: 'settings',
+  };
+
+  #commonStats = {
+    averageGlucose: 'averageGlucose',
+    averageDailyDose: 'averageDailyDose',
+    bgExtents: 'bgExtents',
+    carbs: 'carbs',
+    coefficientOfVariation: 'coefficientOfVariation',
+    glucoseManagementIndicator: 'glucoseManagementIndicator',
+    readingsInRange: 'readingsInRange',
+    sensorUsage: 'sensorUsage',
+    standardDev: 'standardDev',
+    timeInAuto: 'timeInAuto',
+    timeInOverride: 'timeInOverride',
+    timeInRange: 'timeInRange',
+    totalInsulin: 'totalInsulin',
   };
 
   #reports = [this.#reportTypes.all];
@@ -156,24 +173,88 @@ class Report {
     };
   }
 
-  buildReportQueries() {
+  getStatsByChartType(chartType, data) {
+    const bgSource = _.get(data, 'metaData.bgSources.current');
+    const cbgSelected = bgSource === 'cbg';
+    const smbgSelected = bgSource === 'smbg';
+    const isAutomatedBasalDevice = _.get(data, 'metaData.latestPumpUpload.isAutomatedBasalDevice');
+    const isSettingsOverrideDevice = _.get(data, 'metaData.latestPumpUpload.isSettingsOverrideDevice');
+
+    const stats = [];
+
+    switch (chartType) {
+      case 'basics':
+        cbgSelected && stats.push(this.#commonStats.timeInRange);
+        smbgSelected && stats.push(this.#commonStats.readingsInRange);
+        stats.push(this.#commonStats.averageGlucose);
+        cbgSelected && stats.push(this.#commonStats.sensorUsage);
+        stats.push(this.#commonStats.totalInsulin);
+        isAutomatedBasalDevice && stats.push(this.#commonStats.timeInAuto);
+        isSettingsOverrideDevice && stats.push(this.#commonStats.timeInOverride);
+        stats.push(this.#commonStats.carbs);
+        stats.push(this.#commonStats.averageDailyDose);
+        cbgSelected && stats.push(this.#commonStats.glucoseManagementIndicator);
+        stats.push(this.#commonStats.standardDev);
+        stats.push(this.#commonStats.coefficientOfVariation);
+        stats.push(this.#commonStats.bgExtents);
+        break;
+
+      case 'daily':
+        cbgSelected && stats.push(this.#commonStats.timeInRange);
+        smbgSelected && stats.push(this.#commonStats.readingsInRange);
+        stats.push(this.#commonStats.averageGlucose);
+        stats.push(this.#commonStats.totalInsulin);
+        isAutomatedBasalDevice && stats.push(this.#commonStats.timeInAuto);
+        isSettingsOverrideDevice && stats.push(this.#commonStats.timeInOverride);
+        stats.push(this.#commonStats.carbs);
+        cbgSelected && stats.push(this.#commonStats.standardDev);
+        cbgSelected && stats.push(this.#commonStats.coefficientOfVariation);
+        break;
+
+      case 'bgLog':
+        stats.push(this.#commonStats.readingsInRange);
+        stats.push(this.#commonStats.averageGlucose);
+        stats.push(this.#commonStats.standardDev);
+        stats.push(this.#commonStats.coefficientOfVariation);
+        break;
+
+      case 'agp':
+        stats.push(this.#commonStats.timeInRange);
+        stats.push(this.#commonStats.averageGlucose);
+        stats.push(this.#commonStats.sensorUsage);
+        stats.push(this.#commonStats.glucoseManagementIndicator);
+        stats.push(this.#commonStats.coefficientOfVariation);
+        break;
+
+      case 'trends':
+        cbgSelected && stats.push(this.#commonStats.timeInRange);
+        smbgSelected && stats.push(this.#commonStats.readingsInRange);
+        stats.push(this.#commonStats.averageGlucose);
+        cbgSelected && stats.push(this.#commonStats.sensorUsage);
+        stats.push(this.#commonStats.totalInsulin);
+        stats.push(this.#commonStats.averageDailyDose);
+        isAutomatedBasalDevice && stats.push(this.#commonStats.timeInAuto);
+        isSettingsOverrideDevice && stats.push(this.#commonStats.timeInOverride);
+        cbgSelected && stats.push(this.#commonStats.glucoseManagementIndicator);
+        stats.push(this.#commonStats.standardDev);
+        stats.push(this.#commonStats.coefficientOfVariation);
+        stats.push(this.#commonStats.bgExtents);
+        break;
+
+      default:
+        break;
+    }
+
+    return stats;
+  }
+
+  buildReportQueries({ data }) {
     const dataQueries = {
       basics: {
         endpoints: [],
         aggregationsByDate: 'basals, boluses, fingersticks, siteChanges',
         bgSource: 'cbg',
-        stats: [
-          'timeInRange',
-          'averageGlucose',
-          'sensorUsage',
-          'totalInsulin',
-          'carbs',
-          'averageDailyDose',
-          'glucoseManagementIndicator',
-          'standardDev',
-          'coefficientOfVariation',
-          'bgExtents',
-        ],
+        stats: this.getStatsByChartType('basics', data),
         excludeDaysWithoutBolus: false,
         bgPrefs: this.getBGPrefs(),
         metaData: 'latestPumpUpload, bgSources',
@@ -183,12 +264,7 @@ class Report {
       bgLog: {
         endpoints: [],
         aggregationsByDate: 'dataByDate',
-        stats: [
-          'readingsInRange',
-          'averageGlucose',
-          'standardDev',
-          'coefficientOfVariation',
-        ],
+        stats: this.getStatsByChartType('bgLog', data),
         types: {
           smbg: {},
         },
@@ -201,14 +277,7 @@ class Report {
       daily: {
         endpoints: [],
         aggregationsByDate: 'dataByDate, statsByDate',
-        stats: [
-          'timeInRange',
-          'averageGlucose',
-          'totalInsulin',
-          'carbs',
-          'standardDev',
-          'coefficientOfVariation',
-        ],
+        stats: this.getStatsByChartType('daily', data),
         types: {
           basal: {},
           bolus: {},
@@ -229,13 +298,7 @@ class Report {
         endpoints: [],
         aggregationsByDate: 'dataByDate, statsByDate',
         bgSource: 'cbg',
-        stats: [
-          'timeInRange',
-          'averageGlucose',
-          'sensorUsage',
-          'glucoseManagementIndicator',
-          'coefficientOfVariation',
-        ],
+        stats: this.getStatsByChartType('agp', data),
         types: {
           cbg: {},
         },
@@ -497,7 +560,7 @@ class Report {
   getReportOptions(data) {
     const datesByReport = this.getDateRangeByReport({ data });
 
-    const reportQueries = this.buildReportQueries();
+    const reportQueries = this.buildReportQueries({ data });
 
     const printOptions = {
       agp: {

--- a/lib/report.js
+++ b/lib/report.js
@@ -702,6 +702,26 @@ class Report {
       fetchConfig,
     );
 
+    if (this.#reportDates) {
+      // fetch the latest pump settings record for date bound reports
+      const pumpSettingsFetch = await fetchUserData(
+        this.#userDetail.userId,
+        {
+          headers: this.#requestData.sessionHeader,
+          params: {
+            type: 'pumpSettings',
+            latest: 1,
+          },
+        },
+      ).catch((error) => {
+        this.#log.error(error);
+      });
+
+      if (pumpSettingsFetch?.length > 0) {
+        userData.push(pumpSettingsFetch[0]);
+      }
+    }
+
     this.#log.debug(`Downloading data for User ${this.#userDetail.userId}...`);
 
     this.#log.debug('add data to dataUtil');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/export",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "main": "app.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
For [BACK-2685], when running reports with a defined date range (as is the case for EHR reports), grab and append the latest pumpSettings datapoint if it exists in order to generate the settings report when the settings upload happens after or prior to the report range

see: https://github.com/tidepool-org/blip/blob/7745908a1bedf9dc013b3903214ba1f0d081855c/app/pages/patientdata/patientdata.js#L1359C7-L1359C7 for the `blip` code that this was largely lifted from

[BACK-2685]: https://tidepool.atlassian.net/browse/BACK-2685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ