### PR TITLE
bump exceljs to 4.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "private": false,
   "dependencies": {
     "@godaddy/terminus": "4.12.1",
-    "@tidepool/data-tools": "2.4.1",
+    "@tidepool/data-tools": "https://github.com/tidepool-org/node-data-tools.git#eric/bump-exceljs-version",
     "@tidepool/viz": "1.37.0",
     "axios": "1.4.0",
     "blob-stream": "0.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -416,16 +416,15 @@
   dependencies:
     tslib "^2.4.0"
 
-"@tidepool/data-tools@2.4.1":
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/@tidepool/data-tools/-/data-tools-2.4.1.tgz#ce0d6e4f8bebf80e5e3193a882b152c9069e3050"
-  integrity sha512-k5IxoeR3cLnmq6LoTGlG7Lhel6QQlxYWp0woqh9Dai8P9O7CKp6pTbArDvo2UHqNRoxl7Esvz020kw3i9rd9ow==
+"@tidepool/data-tools@https://github.com/tidepool-org/node-data-tools.git#eric/bump-exceljs-version":
+  version "2.4.2"
+  resolved "https://github.com/tidepool-org/node-data-tools.git#a0d115bb71b3772ca21ad2ec8ea7b16821c7a19c"
   dependencies:
     JSONStream "1.3.5"
     commander "4.1.1"
     csv-string "3.1.7"
     event-stream "3.3.4"
-    exceljs "4.3.0"
+    exceljs "4.4.0"
     flat "5.0.0"
     lodash "4.17.15"
     mkdirp "1.0.3"
@@ -2017,15 +2016,15 @@ event-stream@3.3.4:
     stream-combiner "~0.0.4"
     through "~2.3.1"
 
-exceljs@4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/exceljs/-/exceljs-4.3.0.tgz#939bc0d4c59c200acadb7051be34d25c109853c4"
-  integrity sha512-hTAeo5b5TPvf8Z02I2sKIT4kSfCnOO2bCxYX8ABqODCdAjppI3gI9VYiGCQQYVcBaBSKlFDMKlAQRqC+kV9O8w==
+exceljs@4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/exceljs/-/exceljs-4.4.0.tgz#cfb1cb8dcc82c760a9fc9faa9e52dadab66b0156"
+  integrity sha512-XctvKaEMaj1Ii9oDOqbW/6e1gXknSY4g/aLCDicOXqBE4M0nRWkUu0PTp++UPNzoFY12BNHMfs/VadKIS6llvg==
   dependencies:
     archiver "^5.0.0"
     dayjs "^1.8.34"
     fast-csv "^4.3.1"
-    jszip "^3.5.0"
+    jszip "^3.10.1"
     readable-stream "^3.6.0"
     saxes "^5.0.1"
     tmp "^0.2.0"
@@ -2892,7 +2891,7 @@ jsonparse@^1.2.0:
     object.assign "^4.1.4"
     object.values "^1.1.6"
 
-jszip@^3.5.0:
+jszip@^3.10.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/jszip/-/jszip-3.10.1.tgz#34aee70eb18ea1faec2f589208a157d1feb091c2"
   integrity sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==


### PR DESCRIPTION
Timeouts are occurring when exporting data. Seems that streaming might be broken. Bumping to latest to see if we get lucky and that fixes the issue.