### PR TITLE
[BACK-2734] Allow displaying PDF reports inline

### DIFF
--- a/lib/handlers/getUserReportsHandler.js
+++ b/lib/handlers/getUserReportsHandler.js
@@ -40,8 +40,6 @@ export default function getUserReportsHandler() {
         inline,
       } = req.query;
 
-      const contentDisposition = inline === 'true' ? 'inline' : 'attachment';
-
       const timer = setTimeout(() => {
         res.emit('timeout', exportTimeout);
       }, exportTimeout);
@@ -66,7 +64,9 @@ export default function getUserReportsHandler() {
 
       const pdfReport = await userReport.generate();
 
-      res.setHeader('Content-Disposition', `${contentDisposition}: filename="report.pdf"`);
+      if (!inline) {
+        res.setHeader('Content-Disposition', 'attachment; filename="report.pdf"');
+      }
       res.setHeader('Content-Type', 'application/octet-stream');
       const blobArrayBuffer = await pdfReport.blob.arrayBuffer();
       const pdfBuffer = Buffer.from(blobArrayBuffer);

--- a/lib/handlers/getUserReportsHandler.js
+++ b/lib/handlers/getUserReportsHandler.js
@@ -67,7 +67,7 @@ export default function getUserReportsHandler() {
       if (!inline) {
         res.setHeader('Content-Disposition', 'attachment; filename="report.pdf"');
       }
-      res.setHeader('Content-Type', 'application/octet-stream');
+      res.setHeader('Content-Type', 'application/pdf');
       const blobArrayBuffer = await pdfReport.blob.arrayBuffer();
       const pdfBuffer = Buffer.from(blobArrayBuffer);
       if (process.env.DEBUG_PDF) {

--- a/lib/handlers/getUserReportsHandler.js
+++ b/lib/handlers/getUserReportsHandler.js
@@ -37,7 +37,10 @@ export default function getUserReportsHandler() {
         reports,
         startDate,
         endDate,
+        inline,
       } = req.query;
+
+      const contentDisposition = inline === 'true' ? 'inline' : 'attachment';
 
       const timer = setTimeout(() => {
         res.emit('timeout', exportTimeout);
@@ -63,7 +66,7 @@ export default function getUserReportsHandler() {
 
       const pdfReport = await userReport.generate();
 
-      res.setHeader('Content-Disposition', 'attachment: filename="report.pdf"');
+      res.setHeader('Content-Disposition', `${contentDisposition}: filename="report.pdf"`);
       res.setHeader('Content-Type', 'application/octet-stream');
       const blobArrayBuffer = await pdfReport.blob.arrayBuffer();
       const pdfBuffer = Buffer.from(blobArrayBuffer);

--- a/lib/report.js
+++ b/lib/report.js
@@ -809,7 +809,9 @@ class Report {
 
   async generate() {
     if (this.#reportDates) {
-      this.userDataQueryParams = this.userDataQueryOptions();
+      this.userDataQueryParams = this.userDataQueryOptions({
+        restrictedToken: this.#requestData.token,
+      });
     } else {
       const serverTime = await getServerTime();
       this.#log.debug('get server time ', serverTime);
@@ -820,6 +822,7 @@ class Report {
           type: this.#reportDataTypes.join(','),
           latest: 1,
           endDate: moment.utc(serverTime).add(1, 'days').toISOString(),
+          restricted_token: this.#requestData.token,
         },
       };
 
@@ -857,6 +860,7 @@ class Report {
           params: {
             type: 'pumpSettings',
             latest: 1,
+            restricted_token: this.#requestData.token,
           },
         },
       ).catch((error) => {
@@ -891,6 +895,7 @@ class Report {
             params: {
               type: 'upload',
               uploadId: latestPumpSettingsUploadId,
+              restricted_token: this.#requestData.token,
             },
           },
         ).catch((error) => {

--- a/lib/report.js
+++ b/lib/report.js
@@ -570,7 +570,7 @@ class Report {
     dates.agpCGM.endDate = lastAGPDate
       ? moment.utc(lastAGPDate).tz(this.#timezoneName).add(1, 'day').startOf('day')
       : endOfToday();
-    dates.agpCGM.startDate = moment.utc(dates.agp.endDate)
+    dates.agpCGM.startDate = moment.utc(dates.agpCGM.endDate)
       .tz(this.#timezoneName)
       .subtract(days.agpCGM - 1, 'days');
 


### PR DESCRIPTION
A new query parameter `inline` was added to the GET reports endpoint to allow Xealth to display user reports inline. By setting "inline=true" the server will respond with a `Content-Disposition: inline` header which will make the browser render the PDF instead of opening a "Save" dialog.