### PR TITLE
[WEB-3063] use provided date range for latest pump settings query

### DIFF
--- a/lib/report.js
+++ b/lib/report.js
@@ -860,6 +860,8 @@ class Report {
           params: {
             type: 'pumpSettings',
             latest: 1,
+            startDate: this.#reportDates.startDate,
+            endDate: this.#reportDates.endDate,
             restricted_token: this.#requestData.token,
           },
         },


### PR DESCRIPTION
[WEB-3063] given a start and end date, ensure that the latest pump settings fetch respects those bounds