### PR TITLE
[WEB-3841] PDF bolus limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/export",
-  "version": "1.7.5",
+  "version": "1.7.6-WEB-3841-pdf-bolus-limit.1",
   "main": "app.mjs",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@babel/preset-env": "7.25.4",
     "@godaddy/terminus": "4.12.1",
     "@tidepool/data-tools": "2.4.2",
-    "@tidepool/viz": "1.46.0",
+    "@tidepool/viz": "1.50.0-WEB-3841-pdf-bolus-limit.1",
     "axios": "1.8.2",
     "babel-core": "7.0.0-bridge.0",
     "blob-stream": "0.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2559,7 +2559,7 @@ __metadata:
     "@babel/preset-env": 7.25.4
     "@godaddy/terminus": 4.12.1
     "@tidepool/data-tools": 2.4.2
-    "@tidepool/viz": 1.46.0
+    "@tidepool/viz": 1.50.0-WEB-3841-pdf-bolus-limit.1
     axios: 1.8.2
     babel-core: 7.0.0-bridge.0
     blob-stream: 0.1.3
@@ -2587,9 +2587,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@tidepool/viz@npm:1.46.0":
-  version: 1.46.0
-  resolution: "@tidepool/viz@npm:1.46.0"
+"@tidepool/viz@npm:1.50.0-WEB-3841-pdf-bolus-limit.1":
+  version: 1.50.0-WEB-3841-pdf-bolus-limit.1
+  resolution: "@tidepool/viz@npm:1.50.0-WEB-3841-pdf-bolus-limit.1"
   dependencies:
     bluebird: 3.7.2
     bows: 1.7.2
@@ -2615,7 +2615,7 @@ __metadata:
     moment: 2.29.4
     moment-timezone: 0.5.43
     parse-svg-path: 0.1.2
-    pdfkit: 0.13.0
+    pdfkit: 0.15.0
     process: 0.11.10
     prop-types: 15.8.1
     react: 16.14.0
@@ -2650,7 +2650,7 @@ __metadata:
     react-dom: 16.x
     react-redux: 8.x
     redux: 4.x
-  checksum: 21f68191ca62ab82ed7004985054b62abb44bdc1e48a1dadf57b195d0852c16d7f80dd1bbb983e2877c4f9694672a453f0093af31a6ba10582e9c7ffb59e831d
+  checksum: cc834ad9de40faeb1f69646f64a433e0c76402bdcfe54b3dd3aad38c700f99e5d4972c85ea988b3bc99e6b90171d37876d89aa5e08f43bdbe2abe7700e93d6b5
   languageName: node
   linkType: hard
 
@@ -9071,18 +9071,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pdfkit@npm:0.13.0, pdfkit@npm:>=0.8.1":
-  version: 0.13.0
-  resolution: "pdfkit@npm:0.13.0"
-  dependencies:
-    crypto-js: "npm:^4.0.0"
-    fontkit: "npm:^1.8.1"
-    linebreak: "npm:^1.0.2"
-    png-js: "npm:^1.0.0"
-  checksum: 1c0875b5cc0cb8dbf06943089244358bd147493b5b453fefc6cabf55e4a4098dead253d14ec859caefaeb35604130faf454ac04f908d99f9c55f9394e9b21d69
-  languageName: node
-  linkType: hard
-
 "pdfkit@npm:0.15.0":
   version: 0.15.0
   resolution: "pdfkit@npm:0.15.0"
@@ -9093,6 +9081,18 @@ __metadata:
     linebreak: "npm:^1.0.2"
     png-js: "npm:^1.0.0"
   checksum: 044d24f0efd563834bc4c45f12be6e91f98e31d0d664b042d89f35588d3fb985134566280bba6fa29360f61ae1ba62310dccba4b0f102aa448f307c6bbe65bd1
+  languageName: node
+  linkType: hard
+
+"pdfkit@npm:>=0.8.1":
+  version: 0.13.0
+  resolution: "pdfkit@npm:0.13.0"
+  dependencies:
+    crypto-js: "npm:^4.0.0"
+    fontkit: "npm:^1.8.1"
+    linebreak: "npm:^1.0.2"
+    png-js: "npm:^1.0.0"
+  checksum: 1c0875b5cc0cb8dbf06943089244358bd147493b5b453fefc6cabf55e4a4098dead253d14ec859caefaeb35604130faf454ac04f908d99f9c55f9394e9b21d69
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
for [WEB-3841], limits 3-hr binned bolus lists in the daily print view to 50 to avoid overflowing the allowed height

alongside https://github.com/tidepool-org/blip/pull/1724 and https://github.com/tidepool-org/viz/pull/529