### PR TITLE
[WEB-4267] incorporate viz "printed on" timezone awareness update

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@babel/preset-env": "7.25.4",
     "@godaddy/terminus": "4.12.1",
     "@tidepool/data-tools": "2.4.2",
-    "@tidepool/viz": "1.53.0-rc.1",
+    "@tidepool/viz": "1.55.0-web-4267-printed-on-tz.1",
     "axios": "1.8.2",
     "babel-core": "7.0.0-bridge.0",
     "blob-stream": "0.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2559,7 +2559,7 @@ __metadata:
     "@babel/preset-env": 7.25.4
     "@godaddy/terminus": 4.12.1
     "@tidepool/data-tools": 2.4.2
-    "@tidepool/viz": 1.53.0-rc.1
+    "@tidepool/viz": 1.55.0-web-4267-printed-on-tz.1
     axios: 1.8.2
     babel-core: 7.0.0-bridge.0
     blob-stream: 0.1.3
@@ -2587,9 +2587,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@tidepool/viz@npm:1.53.0-rc.1":
-  version: 1.53.0-rc.1
-  resolution: "@tidepool/viz@npm:1.53.0-rc.1"
+"@tidepool/viz@npm:1.55.0-web-4267-printed-on-tz.1":
+  version: 1.55.0-web-4267-printed-on-tz.1
+  resolution: "@tidepool/viz@npm:1.55.0-web-4267-printed-on-tz.1"
   dependencies:
     bluebird: 3.7.2
     bows: 1.7.2
@@ -2650,7 +2650,7 @@ __metadata:
     react-dom: 16.x
     react-redux: 8.x
     redux: 4.x
-  checksum: 50f376810df1125d16325b5861c4f4531f576613a4de3c8f27233eb1e42f3a637ae32f1e3df4c8b23ebcda5929b6f68c510e46b7c094590bfef4e50b3d835d4f
+  checksum: 1901085fcfab8b860805f9d1fad7f08c2f76d218e5d34bc1bd1ec513212f4a52396759e9bfb78b1897beaecb3606ca1fff16e1e71dcdd0b4b43e21ef25889ed1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
[WEB-4267]
Updates `@tidepool/viz` dependency incorporating recent improvements and fixes in the viz library related to time zone handling and printed output functionality.

dependent on https://github.com/tidepool-org/viz/pull/594

[WEB-4267]: https://tidepool.atlassian.net/browse/WEB-4267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ