### PR TITLE
WEB-4556  add glycemic ranges support to PDF

### DIFF
--- a/lib/glycemicRanges.mjs
+++ b/lib/glycemicRanges.mjs
@@ -1,0 +1,124 @@
+import * as vizGlycemicRangesNS from '@tidepool/viz/dist/glycemicRanges.js';
+import { mgdLUnits, mmolLUnits } from './utils.mjs';
+
+const vizGlycemicRanges = vizGlycemicRangesNS.default || vizGlycemicRangesNS;
+const { getBgBoundsForGlycemicRanges, DEFAULT_BG_BOUNDS } = vizGlycemicRanges;
+
+/**
+ * Parse a single `glycemicRangeThresholds` query value into a threshold
+ * object. The clinic backend (xealth/report.go) serializes each threshold as
+ * `name,<n>,upperBound.value,<f>,upperBound.units,<u>,inclusive,<bool>` after
+ * CSV-encoding the name to escape embedded commas. This wire format is unique
+ * to the clinic <-> export contract, so the parser lives here rather than in
+ * viz.
+ *
+ * @param {string} raw
+ * @returns {{ name: string, upperBound: { value: number, units: string },
+ *   inclusive: boolean } | null}
+ */
+export function parseThreshold(raw) {
+  if (typeof raw !== 'string' || raw.length === 0) return null;
+
+  const parts = [];
+  let inQuotes = false;
+  let buf = '';
+  for (let i = 0; i < raw.length; i += 1) {
+    const ch = raw[i];
+    if (ch === '"') {
+      if (inQuotes && raw[i + 1] === '"') {
+        buf += '"';
+        i += 1;
+      } else {
+        inQuotes = !inQuotes;
+      }
+    } else if (ch === ',' && !inQuotes) {
+      parts.push(buf);
+      buf = '';
+    } else {
+      buf += ch;
+    }
+  }
+  parts.push(buf);
+
+  const fields = {};
+  for (let i = 0; i + 1 < parts.length; i += 2) {
+    fields[parts[i]] = parts[i + 1];
+  }
+
+  if (typeof fields.name !== 'string') return null;
+
+  const value = Number.parseFloat(fields['upperBound.value']);
+  if (!Number.isFinite(value)) return null;
+
+  return {
+    name: fields.name,
+    upperBound: {
+      value,
+      units: fields['upperBound.units'],
+    },
+    inclusive: fields.inclusive === 'true',
+  };
+}
+
+export function parseThresholds(raw) {
+  if (raw == null) return [];
+  const list = Array.isArray(raw) ? raw : [raw];
+  return list.map((entry) => parseThreshold(entry)).filter(Boolean);
+}
+
+/**
+ * Adapt the flat (type, preset) shape we receive from clinic's query string
+ * to the {type, preset} object viz expects, then ask viz for the *raw* preset
+ * bgBounds. Single source of truth lives in viz.
+ *
+ * Note: these are the unmodified preset bounds — for adaHighRisk and the
+ * pregnancy presets, `extremeHighThreshold` is intentionally `null`. The PDF
+ * pipeline is fed the reshaped bounds from `getBgPrefsForGlycemicRange` below,
+ * not these directly.
+ */
+export function getRawPresetBgBounds({ bgUnits, type, preset } = {}) {
+  const units = bgUnits === mgdLUnits ? mgdLUnits : mmolLUnits;
+  return { ...getBgBoundsForGlycemicRanges(type ? { type, preset } : null, units) };
+}
+
+/**
+ * Build the full bgPrefs ({ bgUnits, bgClasses, bgBounds }) for a glycemic-range
+ * selection, reproducing blip's clinician path EXACTLY so export PDFs render
+ * identically to blip's.
+ *
+ * STOPGAP — intentional parity.
+ * blip (blip/app/core/utils.js `getBGPrefsForDataProcessing`) resolves the
+ * preset to a bounds table, builds a 5-class bgClasses, then runs it through
+ * viz's `reshapeBgClassesToBgBounds`. That reshape predates
+ * the glycemic-range presets — hardcodes `extremeHighThreshold` and
+ * `clampThreshold` to the unit DEFAULTS, overriding the preset table's
+ * intentionally-null extreme-high for adaHighRisk / pregnancy presets. We
+ * deliberately mirror that here (including the override) so the two renderers
+ * agree.
+ */
+export function getBgPrefsForGlycemicRange({ bgUnits, type, preset } = {}) {
+  const units = bgUnits === mgdLUnits ? mgdLUnits : mmolLUnits;
+  const bounds = getRawPresetBgBounds({ bgUnits: units, type, preset });
+
+  // Mirror blip's bgClasses construction (5 classes, falsy -> null).
+  const bgClasses = {
+    'very-low': { boundary: bounds.veryLowThreshold || null },
+    low: { boundary: bounds.targetLowerBound || null },
+    target: { boundary: bounds.targetUpperBound || null },
+    high: { boundary: bounds.veryHighThreshold || null },
+    'very-high': { boundary: bounds.extremeHighThreshold || null },
+  };
+
+  // Mirror viz's reshapeBgClassesToBgBounds: category boundaries come from the
+  // preset, but extremeHighThreshold and clampThreshold are forced to defaults.
+  const bgBounds = {
+    veryLowThreshold: bgClasses['very-low'].boundary,
+    targetLowerBound: bgClasses.low.boundary,
+    targetUpperBound: bgClasses.target.boundary,
+    veryHighThreshold: bgClasses.high.boundary,
+    extremeHighThreshold: DEFAULT_BG_BOUNDS[units].extremeHighThreshold,
+    clampThreshold: DEFAULT_BG_BOUNDS[units].clampThreshold,
+  };
+
+  return { bgUnits: units, bgClasses, bgBounds };
+}

--- a/lib/glycemicRanges.mjs
+++ b/lib/glycemicRanges.mjs
@@ -50,11 +50,14 @@ export function parseThreshold(raw) {
   const value = Number.parseFloat(fields['upperBound.value']);
   if (!Number.isFinite(value)) return null;
 
+  const units = fields['upperBound.units'];
+  if (typeof units !== 'string' || units.length === 0) return null;
+
   return {
     name: fields.name,
     upperBound: {
       value,
-      units: fields['upperBound.units'],
+      units,
     },
     inclusive: fields.inclusive === 'true',
   };

--- a/lib/handlers/getUserReportsHandler.mjs
+++ b/lib/handlers/getUserReportsHandler.mjs
@@ -38,6 +38,9 @@ export default function getUserReportsHandler() {
         startDate,
         endDate,
         inline,
+        glycemicRangeType,
+        glycemicRangePreset,
+        glycemicRangeThresholds,
       } = req.query;
 
       const timer = setTimeout(() => {
@@ -58,6 +61,9 @@ export default function getUserReportsHandler() {
           reports,
           startDate,
           endDate,
+          glycemicRangeType,
+          glycemicRangePreset,
+          glycemicRangeThresholds,
         },
         { token: restrictedToken, sessionHeader: getSessionHeader(req) },
       );

--- a/lib/report.mjs
+++ b/lib/report.mjs
@@ -11,6 +11,10 @@ import blobStream from 'blob-stream';
 import {
   fetchUserData, getServerTime, mgdLUnits, mmolLUnits,
 } from './utils.mjs';
+import {
+  getBgPrefsForGlycemicRange,
+  parseThresholds,
+} from './glycemicRanges.mjs';
 
 const { DataUtil } = vizDataUtil;
 const { createPrintPDFPackage, utils: PrintPDFUtils } = vizPrintUtil;
@@ -91,6 +95,12 @@ class Report {
 
   #reports = [this.#reportTypes.all];
 
+  #glycemicRangeType;
+
+  #glycemicRangePreset;
+
+  #glycemicRangeThresholds = [];
+
   #reportDates;
 
   #log;
@@ -116,6 +126,9 @@ class Report {
    *   reports: Array|null;
    *   startDate: string|null;
    *   endDate: string|null;
+   *   glycemicRangeType: string|null;
+   *   glycemicRangePreset: string|null;
+   *   glycemicRangeThresholds: Array|string|null;
    *  }} reportDetail
    * @param {{
    *   token: string;
@@ -127,7 +140,14 @@ class Report {
     this.#log = log;
     this.#userDetail = userDetail;
     const {
-      tzName, bgUnits, reports, startDate, endDate,
+      tzName,
+      bgUnits,
+      reports,
+      startDate,
+      endDate,
+      glycemicRangeType,
+      glycemicRangePreset,
+      glycemicRangeThresholds,
     } = reportDetail;
 
     if (tzName) {
@@ -142,6 +162,20 @@ class Report {
     if (startDate && endDate) {
       this.#reportDates = { startDate, endDate };
     }
+    if (glycemicRangeType) {
+      this.#glycemicRangeType = glycemicRangeType;
+    }
+    if (glycemicRangePreset) {
+      this.#glycemicRangePreset = glycemicRangePreset;
+    }
+    if (glycemicRangeThresholds != null) {
+      try {
+        this.#glycemicRangeThresholds = parseThresholds(glycemicRangeThresholds);
+      } catch (err) {
+        this.#log.warn('Failed to parse glycemicRangeThresholds, using empty default', { err });
+        this.#glycemicRangeThresholds = [];
+      }
+    }
     this.#requestData = requestData;
     this.#dataUtil = new DataUtil();
   }
@@ -154,44 +188,11 @@ class Report {
   }
 
   getBGPrefs() {
-    if (this.#bgUnits === mgdLUnits) {
-      return {
-        bgUnits: mgdLUnits,
-        bgClasses: {
-          low: {
-            boundary: 70,
-          },
-          target: {
-            boundary: 180,
-          },
-        },
-        bgBounds: {
-          veryHighThreshold: 250,
-          targetUpperBound: 180,
-          targetLowerBound: 70,
-          veryLowThreshold: 54,
-          clampThreshold: 600,
-        },
-      };
-    }
-    return {
-      bgUnits: mmolLUnits,
-      bgClasses: {
-        low: {
-          boundary: 3.9,
-        },
-        target: {
-          boundary: 10,
-        },
-      },
-      bgBounds: {
-        veryHighThreshold: 13.9,
-        targetUpperBound: 10,
-        targetLowerBound: 3.9,
-        veryLowThreshold: 3,
-        clampThreshold: 33.3,
-      },
-    };
+    return getBgPrefsForGlycemicRange({
+      bgUnits: this.#bgUnits,
+      type: this.#glycemicRangeType,
+      preset: this.#glycemicRangePreset,
+    });
   }
 
   getLatestTimezone(data) {

--- a/lib/report.mjs
+++ b/lib/report.mjs
@@ -9,7 +9,7 @@ import * as PDFKit from 'pdfkit';
 
 import blobStream from 'blob-stream';
 import {
-  fetchUserData, getServerTime, mgdLUnits, mmolLUnits,
+  fetchUserData, getServerTime, mmolLUnits,
 } from './utils.mjs';
 import {
   getBgPrefsForGlycemicRange,
@@ -168,6 +168,11 @@ class Report {
     if (glycemicRangePreset) {
       this.#glycemicRangePreset = glycemicRangePreset;
     }
+    // Forward-looking: clinic already sends custom thresholds on the query
+    // string, but the `custom` glycemic-range path is not live yet, so
+    // getBGPrefs() resolves bgPrefs from type/preset only and does not consume
+    // #glycemicRangeThresholds. We parse and retain them now so wiring up the
+    // custom path later is additive rather than a retool.
     if (glycemicRangeThresholds != null) {
       try {
         this.#glycemicRangeThresholds = parseThresholds(glycemicRangeThresholds);

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@babel/preset-env": "7.25.4",
     "@godaddy/terminus": "4.12.1",
     "@tidepool/data-tools": "2.5.0",
-    "@tidepool/viz": "1.57.0",
+    "@tidepool/viz": "1.59.0-web-4556-glycemic-ranges.1",
     "axios": "1.8.2",
     "babel-core": "7.0.0-bridge.0",
     "blob-stream": "0.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/export",
-  "version": "1.7.6-WEB-3841-pdf-bolus-limit.1",
+  "version": "1.7.8-WEB-4556-glycemic-ranges.1",
   "main": "app.mjs",
   "repository": {
     "type": "git",

--- a/test/getUserReportsHandler.test.js
+++ b/test/getUserReportsHandler.test.js
@@ -1,0 +1,109 @@
+// Tests that getUserReportsHandler forwards the glycemic-range query params to
+// the Report unchanged. Parsing of the CSV-encoded thresholds is Report's job
+// (via lib/glycemicRanges.mjs parseThresholds), not the handler's.
+// Each test loads the handler with fresh mocks via jest.isolateModules to avoid
+// hoisting issues with ESM default-export mocks.
+
+const mockGenerateFn = jest.fn().mockResolvedValue({
+  blob: {
+    arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(4)),
+  },
+});
+
+const mockReportConstructor = jest.fn().mockImplementation(() => ({
+  generate: mockGenerateFn,
+}));
+
+function makeReq(query = {}) {
+  return {
+    params: { userid: 'user-123' },
+    query: {
+      bgUnits: 'mmol/L',
+      tzName: 'UTC',
+      reports: ['all'],
+      ...query,
+    },
+    setTimeout: jest.fn(),
+  };
+}
+
+function makeRes() {
+  return {
+    setHeader: jest.fn(),
+    send: jest.fn(),
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn(),
+    emit: jest.fn(),
+  };
+}
+
+async function invokeHandler(query) {
+  let getUserReportsHandler;
+  jest.isolateModules(() => {
+    jest.doMock('../lib/report.mjs', () => ({
+      __esModule: true,
+      default: { Report: mockReportConstructor },
+    }));
+    jest.doMock('../lib/utils.mjs', () => ({
+      getSessionHeader: jest.fn().mockReturnValue({}),
+      createCounter: jest.fn().mockReturnValue({ inc: jest.fn() }),
+      exportTimeout: 1000,
+      logMaker: jest.fn().mockReturnValue({
+        info: jest.fn(),
+        error: jest.fn(),
+        warn: jest.fn(),
+      }),
+    }));
+    // eslint-disable-next-line global-require
+    getUserReportsHandler = require('../lib/handlers/getUserReportsHandler.mjs').default;
+  });
+
+  mockReportConstructor.mockClear();
+  const middleware = getUserReportsHandler();
+  const req = makeReq(query);
+  const res = makeRes();
+  jest.useFakeTimers();
+  const promise = middleware(req, res);
+  jest.runAllTimers();
+  jest.useRealTimers();
+  await promise;
+
+  if (res.status.mock.calls.length > 0) {
+    const [statusCode] = res.status.mock.calls[0];
+    const [{ message } = {}] = res.json.mock.calls[0] || [{}];
+    throw new Error(`Handler returned status ${statusCode}: ${message}`);
+  }
+  expect(mockReportConstructor).toHaveBeenCalled();
+  return mockReportConstructor.mock.calls[0][2]; // reportDetail arg
+}
+
+describe('getUserReportsHandler – glycemic-range query params', () => {
+  it('forwards glycemicRangeType and glycemicRangePreset unchanged', async () => {
+    const reportDetail = await invokeHandler({
+      glycemicRangeType: 'preset',
+      glycemicRangePreset: 'adaPregnancyType1',
+    });
+    expect(reportDetail.glycemicRangeType).toBe('preset');
+    expect(reportDetail.glycemicRangePreset).toBe('adaPregnancyType1');
+  });
+
+  it('leaves glycemicRangeThresholds undefined when absent', async () => {
+    const reportDetail = await invokeHandler({});
+    expect(reportDetail.glycemicRangeThresholds).toBeUndefined();
+  });
+
+  it('forwards a single CSV-encoded threshold string unchanged', async () => {
+    const raw = 'name,low,upperBound.value,70,upperBound.units,mg/dL,inclusive,true';
+    const reportDetail = await invokeHandler({ glycemicRangeThresholds: raw });
+    expect(reportDetail.glycemicRangeThresholds).toBe(raw);
+  });
+
+  it('forwards a repeated (array) threshold param unchanged', async () => {
+    const thresholds = [
+      'name,low,upperBound.value,70,upperBound.units,mg/dL,inclusive,true',
+      'name,high,upperBound.value,180,upperBound.units,mg/dL,inclusive,false',
+    ];
+    const reportDetail = await invokeHandler({ glycemicRangeThresholds: thresholds });
+    expect(reportDetail.glycemicRangeThresholds).toEqual(thresholds);
+  });
+});

--- a/test/glycemicRanges.test.js
+++ b/test/glycemicRanges.test.js
@@ -173,7 +173,9 @@ describe('glycemicRanges', () => {
 
   // STOPGAP parity: getBgPrefsForGlycemicRange must reproduce blip's reshape
   // behavior, where extremeHighThreshold is forced to the unit default even for
-  // presets whose raw table value is null. See docs/glycemic-ranges-parity.md.
+  // presets whose raw table value is null (blip/app/core/utils.js
+  // getBGPrefsForDataProcessing -> viz reshapeBgClassesToBgBounds). These tests
+  // are canaries: if viz stops forcing the default, they fail on purpose.
   describe('getBgPrefsForGlycemicRange (blip parity)', () => {
     it('forces extremeHighThreshold to the unit default for adaHighRisk (raw is null)', () => {
       const raw = getRawPresetBgBounds({

--- a/test/glycemicRanges.test.js
+++ b/test/glycemicRanges.test.js
@@ -1,0 +1,218 @@
+import {
+  parseThreshold,
+  parseThresholds,
+  getRawPresetBgBounds,
+  getBgPrefsForGlycemicRange,
+} from '../lib/glycemicRanges.mjs';
+import { mgdLUnits, mmolLUnits } from '../lib/utils.mjs';
+
+describe('glycemicRanges', () => {
+  describe('parseThreshold', () => {
+    it('parses a well-formed threshold string', () => {
+      expect(
+        parseThreshold(
+          'name,low,upperBound.value,70.000000,upperBound.units,mg/dL,inclusive,true',
+        ),
+      ).toEqual({
+        name: 'low',
+        upperBound: { value: 70, units: 'mg/dL' },
+        inclusive: true,
+      });
+    });
+
+    it('parses a name containing a comma (CSV-quoted, as serialized by clinic)', () => {
+      // clinic uses encoding/csv.Writer, which quotes any field containing a
+      // comma and doubles internal quotes.
+      expect(
+        parseThreshold(
+          'name,"foo, bar",upperBound.value,180.000000,upperBound.units,mg/dL,inclusive,false',
+        ),
+      ).toEqual({
+        name: 'foo, bar',
+        upperBound: { value: 180, units: 'mg/dL' },
+        inclusive: false,
+      });
+    });
+
+    it('parses a name containing escaped quotes', () => {
+      expect(
+        parseThreshold(
+          'name,"she said ""hi""",upperBound.value,140.000000,upperBound.units,mg/dL,inclusive,true',
+        ),
+      ).toEqual({
+        name: 'she said "hi"',
+        upperBound: { value: 140, units: 'mg/dL' },
+        inclusive: true,
+      });
+    });
+
+    it('returns null for non-string or empty input', () => {
+      expect(parseThreshold('')).toBeNull();
+      expect(parseThreshold(null)).toBeNull();
+      expect(parseThreshold(undefined)).toBeNull();
+    });
+
+    it('returns null when upperBound.value is not a number', () => {
+      expect(
+        parseThreshold(
+          'name,low,upperBound.value,nope,upperBound.units,mg/dL,inclusive,true',
+        ),
+      ).toBeNull();
+    });
+  });
+
+  describe('parseThresholds', () => {
+    it('returns [] for missing input', () => {
+      expect(parseThresholds()).toEqual([]);
+      expect(parseThresholds(null)).toEqual([]);
+    });
+
+    it('accepts a single string (express coerces a single repeat to a string)', () => {
+      const out = parseThresholds(
+        'name,low,upperBound.value,70.000000,upperBound.units,mg/dL,inclusive,true',
+      );
+      expect(out).toHaveLength(1);
+    });
+
+    it('accepts an array (express coerces multiple repeats to an array)', () => {
+      const out = parseThresholds([
+        'name,low,upperBound.value,70.000000,upperBound.units,mg/dL,inclusive,true',
+        'name,high,upperBound.value,180.000000,upperBound.units,mg/dL,inclusive,false',
+      ]);
+      expect(out).toHaveLength(2);
+    });
+
+    it('skips invalid entries', () => {
+      const out = parseThresholds([
+        'name,low,upperBound.value,70.000000,upperBound.units,mg/dL,inclusive,true',
+        'totally bogus',
+      ]);
+      expect(out).toHaveLength(1);
+    });
+  });
+
+  describe('getRawPresetBgBounds', () => {
+    it('returns ADA standard bounds when nothing is supplied', () => {
+      expect(getRawPresetBgBounds({ bgUnits: mgdLUnits })).toEqual({
+        veryLowThreshold: 54,
+        targetLowerBound: 70,
+        targetUpperBound: 180,
+        veryHighThreshold: 250,
+        extremeHighThreshold: 350,
+        clampThreshold: 600,
+      });
+    });
+
+    it('returns ADA pregnancy type 1 bounds in mmol/L', () => {
+      expect(
+        getRawPresetBgBounds({
+          bgUnits: mmolLUnits,
+          type: 'preset',
+          preset: 'adaPregnancyType1',
+        }),
+      ).toEqual({
+        veryLowThreshold: 3.0,
+        targetLowerBound: 3.5,
+        targetUpperBound: 7.8,
+        veryHighThreshold: null,
+        extremeHighThreshold: null,
+        clampThreshold: 33.3,
+      });
+    });
+
+    it('returns ADA older/high-risk bounds in mg/dL', () => {
+      expect(
+        getRawPresetBgBounds({
+          bgUnits: mgdLUnits,
+          type: 'preset',
+          preset: 'adaHighRisk',
+        }),
+      ).toEqual({
+        veryLowThreshold: null,
+        targetLowerBound: 70,
+        targetUpperBound: 180,
+        veryHighThreshold: 250,
+        extremeHighThreshold: null,
+        clampThreshold: 600,
+      });
+    });
+
+    it('falls back to ADA standard for unknown preset', () => {
+      expect(
+        getRawPresetBgBounds({
+          bgUnits: mgdLUnits,
+          type: 'preset',
+          preset: 'noSuchPreset',
+        }),
+      ).toEqual({
+        veryLowThreshold: 54,
+        targetLowerBound: 70,
+        targetUpperBound: 180,
+        veryHighThreshold: 250,
+        extremeHighThreshold: 350,
+        clampThreshold: 600,
+      });
+    });
+
+    it('falls back to ADA standard for custom type (parity with viz)', () => {
+      expect(
+        getRawPresetBgBounds({
+          bgUnits: mmolLUnits,
+          type: 'custom',
+        }),
+      ).toEqual({
+        veryLowThreshold: 3.0,
+        targetLowerBound: 3.9,
+        targetUpperBound: 10.0,
+        veryHighThreshold: 13.9,
+        extremeHighThreshold: 19.4,
+        clampThreshold: 33.3,
+      });
+    });
+  });
+
+  // STOPGAP parity: getBgPrefsForGlycemicRange must reproduce blip's reshape
+  // behavior, where extremeHighThreshold is forced to the unit default even for
+  // presets whose raw table value is null. See docs/glycemic-ranges-parity.md.
+  describe('getBgPrefsForGlycemicRange (blip parity)', () => {
+    it('forces extremeHighThreshold to the unit default for adaHighRisk (raw is null)', () => {
+      const raw = getRawPresetBgBounds({
+        bgUnits: mgdLUnits, type: 'preset', preset: 'adaHighRisk',
+      });
+      const prefs = getBgPrefsForGlycemicRange({
+        bgUnits: mgdLUnits, type: 'preset', preset: 'adaHighRisk',
+      });
+
+      // The raw preset bounds intentionally carry a null extreme-high...
+      expect(raw.extremeHighThreshold).toBeNull();
+      // ...but the rendered bgPrefs match blip: forced to the default.
+      expect(prefs.bgBounds.extremeHighThreshold).toBe(350);
+      expect(prefs.bgClasses['very-high']).toEqual({ boundary: null });
+    });
+
+    it('builds the full 5-class bgPrefs for adaPregnancyType1 in mmol/L', () => {
+      expect(
+        getBgPrefsForGlycemicRange({
+          bgUnits: mmolLUnits, type: 'preset', preset: 'adaPregnancyType1',
+        }),
+      ).toEqual({
+        bgUnits: mmolLUnits,
+        bgClasses: {
+          'very-low': { boundary: 3.0 },
+          low: { boundary: 3.5 },
+          target: { boundary: 7.8 },
+          high: { boundary: null },
+          'very-high': { boundary: null },
+        },
+        bgBounds: {
+          veryLowThreshold: 3.0,
+          targetLowerBound: 3.5,
+          targetUpperBound: 7.8,
+          veryHighThreshold: null,
+          extremeHighThreshold: 19.4,
+          clampThreshold: 33.3,
+        },
+      });
+    });
+  });
+});

--- a/test/report.test.js
+++ b/test/report.test.js
@@ -25,36 +25,36 @@ describe('report', () => {
   const expectedMgdLPref = {
     bgUnits: mgdLUnits,
     bgClasses: {
-      low: {
-        boundary: 70,
-      },
-      target: {
-        boundary: 180,
-      },
+      'very-low': { boundary: 54 },
+      low: { boundary: 70 },
+      target: { boundary: 180 },
+      high: { boundary: 250 },
+      'very-high': { boundary: 350 },
     },
     bgBounds: {
-      veryHighThreshold: 250,
-      targetUpperBound: 180,
-      targetLowerBound: 70,
       veryLowThreshold: 54,
+      targetLowerBound: 70,
+      targetUpperBound: 180,
+      veryHighThreshold: 250,
+      extremeHighThreshold: 350,
       clampThreshold: 600,
     },
   };
   const expectedMmoLPref = {
     bgUnits: mmolLUnits,
     bgClasses: {
-      low: {
-        boundary: 3.9,
-      },
-      target: {
-        boundary: 10,
-      },
+      'very-low': { boundary: 3.0 },
+      low: { boundary: 3.9 },
+      target: { boundary: 10.0 },
+      high: { boundary: 13.9 },
+      'very-high': { boundary: 19.4 },
     },
     bgBounds: {
-      veryHighThreshold: 13.9,
-      targetUpperBound: 10,
+      veryLowThreshold: 3.0,
       targetLowerBound: 3.9,
-      veryLowThreshold: 3,
+      targetUpperBound: 10.0,
+      veryHighThreshold: 13.9,
+      extremeHighThreshold: 19.4,
       clampThreshold: 33.3,
     },
   };
@@ -424,6 +424,196 @@ describe('report', () => {
         requestDetail,
       );
 
+      expect(r.getBGPrefs()).toEqual(expectedMmoLPref);
+    });
+
+    it('should default to ADA standard bounds when no glycemic range is supplied', () => {
+      const r = new Report(
+        testLog,
+        userDetails,
+        { bgUnits: mgdLUnits },
+        requestDetail,
+      );
+
+      expect(r.getBGPrefs()).toEqual(expectedMgdLPref);
+    });
+
+    it('should apply ADA older/high-risk preset bounds in mg/dL', () => {
+      const r = new Report(
+        testLog,
+        userDetails,
+        {
+          bgUnits: mgdLUnits,
+          glycemicRangeType: 'preset',
+          glycemicRangePreset: 'adaHighRisk',
+        },
+        requestDetail,
+      );
+
+      expect(r.getBGPrefs()).toEqual({
+        bgUnits: mgdLUnits,
+        bgClasses: {
+          'very-low': { boundary: null },
+          low: { boundary: 70 },
+          target: { boundary: 180 },
+          high: { boundary: 250 },
+          'very-high': { boundary: null },
+        },
+        bgBounds: {
+          veryLowThreshold: null,
+          targetLowerBound: 70,
+          targetUpperBound: 180,
+          veryHighThreshold: 250,
+          // Forced to the unit default by blip's reshape (preset value is null).
+          extremeHighThreshold: 350,
+          clampThreshold: 600,
+        },
+      });
+    });
+
+    it('should apply ADA pregnancy type 1 preset bounds in mg/dL', () => {
+      const r = new Report(
+        testLog,
+        userDetails,
+        {
+          bgUnits: mgdLUnits,
+          glycemicRangeType: 'preset',
+          glycemicRangePreset: 'adaPregnancyType1',
+        },
+        requestDetail,
+      );
+
+      expect(r.getBGPrefs()).toEqual({
+        bgUnits: mgdLUnits,
+        bgClasses: {
+          'very-low': { boundary: 54 },
+          low: { boundary: 63 },
+          target: { boundary: 140 },
+          high: { boundary: null },
+          'very-high': { boundary: null },
+        },
+        bgBounds: {
+          veryLowThreshold: 54,
+          targetLowerBound: 63,
+          targetUpperBound: 140,
+          veryHighThreshold: null,
+          // Forced to the unit default by blip's reshape (preset value is null).
+          extremeHighThreshold: 350,
+          clampThreshold: 600,
+        },
+      });
+    });
+
+    it('should apply ADA pregnancy type 2 (gestational) preset bounds in mmol/L', () => {
+      const r = new Report(
+        testLog,
+        userDetails,
+        {
+          bgUnits: mmolLUnits,
+          glycemicRangeType: 'preset',
+          glycemicRangePreset: 'adaPregnancyType2',
+        },
+        requestDetail,
+      );
+
+      expect(r.getBGPrefs()).toEqual({
+        bgUnits: mmolLUnits,
+        bgClasses: {
+          'very-low': { boundary: 3.0 },
+          low: { boundary: 3.5 },
+          target: { boundary: 7.8 },
+          high: { boundary: null },
+          'very-high': { boundary: null },
+        },
+        bgBounds: {
+          veryLowThreshold: 3.0,
+          targetLowerBound: 3.5,
+          targetUpperBound: 7.8,
+          veryHighThreshold: null,
+          // Forced to the unit default by blip's reshape (preset value is null).
+          extremeHighThreshold: 19.4,
+          clampThreshold: 33.3,
+        },
+      });
+    });
+
+    it('should fall back to ADA standard when preset is unrecognized', () => {
+      const r = new Report(
+        testLog,
+        userDetails,
+        {
+          bgUnits: mgdLUnits,
+          glycemicRangeType: 'preset',
+          glycemicRangePreset: 'somethingBogus',
+        },
+        requestDetail,
+      );
+
+      expect(r.getBGPrefs()).toEqual(expectedMgdLPref);
+    });
+
+    it('should fall back to ADA standard for custom-type ranges (matching viz)', () => {
+      const r = new Report(
+        testLog,
+        userDetails,
+        {
+          bgUnits: mgdLUnits,
+          glycemicRangeType: 'custom',
+          glycemicRangeThresholds: [
+            'name,low,upperBound.value,80.000000,upperBound.units,mg/dL,inclusive,true',
+            'name,high,upperBound.value,200.000000,upperBound.units,mg/dL,inclusive,false',
+          ],
+        },
+        requestDetail,
+      );
+
+      expect(r.getBGPrefs()).toEqual(expectedMgdLPref);
+    });
+
+    it('should not throw when a preset has null bound values (e.g. adaHighRisk)', () => {
+      // Verifies the null guard does not falsely reject intentionally-null properties
+      const r = new Report(
+        testLog,
+        userDetails,
+        {
+          bgUnits: mgdLUnits,
+          glycemicRangeType: 'preset',
+          glycemicRangePreset: 'adaHighRisk',
+        },
+        requestDetail,
+      );
+
+      expect(() => r.getBGPrefs()).not.toThrow();
+    });
+  });
+
+  describe('Report constructor – glycemicRangeThresholds resilience', () => {
+    it('should not throw when glycemicRangeThresholds is null', () => {
+      expect(() => new Report(
+        testLog,
+        userDetails,
+        { bgUnits: mmolLUnits, glycemicRangeThresholds: null },
+        requestDetail,
+      )).not.toThrow();
+    });
+
+    it('should not throw when glycemicRangeThresholds entries are malformed strings', () => {
+      expect(() => new Report(
+        testLog,
+        userDetails,
+        { bgUnits: mmolLUnits, glycemicRangeThresholds: ['not-a-valid-threshold', ''] },
+        requestDetail,
+      )).not.toThrow();
+    });
+
+    it('should silently skip malformed threshold entries and produce empty thresholds', () => {
+      const r = new Report(
+        testLog,
+        userDetails,
+        { bgUnits: mmolLUnits, glycemicRangeThresholds: ['not-a-valid-threshold'] },
+        requestDetail,
+      );
+      // Malformed entries are dropped; falls back to ADA standard bounds
       expect(r.getBGPrefs()).toEqual(expectedMmoLPref);
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2559,7 +2559,7 @@ __metadata:
     "@babel/preset-env": 7.25.4
     "@godaddy/terminus": 4.12.1
     "@tidepool/data-tools": 2.5.0
-    "@tidepool/viz": 1.57.0
+    "@tidepool/viz": 1.59.0-web-4556-glycemic-ranges.1
     axios: 1.8.2
     babel-core: 7.0.0-bridge.0
     blob-stream: 0.1.3
@@ -2587,9 +2587,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@tidepool/viz@npm:1.57.0":
-  version: 1.57.0
-  resolution: "@tidepool/viz@npm:1.57.0"
+"@tidepool/viz@npm:1.59.0-web-4556-glycemic-ranges.1":
+  version: 1.59.0-web-4556-glycemic-ranges.1
+  resolution: "@tidepool/viz@npm:1.59.0-web-4556-glycemic-ranges.1"
   dependencies:
     bluebird: 3.7.2
     bows: 1.7.2
@@ -2650,7 +2650,7 @@ __metadata:
     react-dom: 16.x
     react-redux: 8.x
     redux: 4.x
-  checksum: 5d900aacd55c5522e1b85b1964c3e397d1fb7b8a7e15b58da17936c0244b98217f3543a663779096b9632d0ebf6264ed4e9ab889260094222efe825b827dca3e
+  checksum: 15c9a0c8c4699383a3a0e8eb90473aac73c5899c7e7d8f37c7b13309b1c60b6779d4f0fb0f7a8c105ef2c567d024e10ebb5c2e5eb02ffe9030344a112f550ad8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
for [WEB-4556] related viz PR: https://github.com/tidepool-org/viz/pull/657
This pull request adds support for glycemic range presets and custom thresholds to the report export pipeline, ensuring parity with the clinician-facing renderer ("blip") and enabling new glycemic-range options in exported PDFs. It introduces a new module for glycemic range parsing and logic, updates the report handling to accept and process glycemic range parameters, and adds comprehensive tests for these features.

**Support for glycemic range presets and thresholds:**

* Added a new module `lib/glycemicRanges.mjs` that implements parsing of CSV-encoded glycemic range thresholds, adapts clinic query parameters to the shape expected by the viz library, and reproduces blip's logic for glycemic range bounds and preferences.
* Updated the report handler (`lib/handlers/getUserReportsHandler.mjs`) to accept and forward new glycemic range query parameters (`glycemicRangeType`, `glycemicRangePreset`, `glycemicRangeThresholds`). [[1]](diffhunk://#diff-4f1f2b8ab73e35357d8c1047156d1c6a06627f3ab90d9a065020f571863520e3R41-R43) [[2]](diffhunk://#diff-4f1f2b8ab73e35357d8c1047156d1c6a06627f3ab90d9a065020f571863520e3R64-R66)
* The `Report` class now stores and processes glycemic range parameters, parsing thresholds as needed and using the new logic to compute BG preferences for the export. [[1]](diffhunk://#diff-77c767c7236427bf960de1854c4e41b240fd220b8ab38b59bc6b611af2725810R14-R17) [[2]](diffhunk://#diff-77c767c7236427bf960de1854c4e41b240fd220b8ab38b59bc6b611af2725810R98-R103) [[3]](diffhunk://#diff-77c767c7236427bf960de1854c4e41b240fd220b8ab38b59bc6b611af2725810R129-R131) [[4]](diffhunk://#diff-77c767c7236427bf960de1854c4e41b240fd220b8ab38b59bc6b611af2725810L130-R150) [[5]](diffhunk://#diff-77c767c7236427bf960de1854c4e41b240fd220b8ab38b59bc6b611af2725810R165-R178) [[6]](diffhunk://#diff-77c767c7236427bf960de1854c4e41b240fd220b8ab38b59bc6b611af2725810L157-R195)

**Testing and validation:**

* Added unit tests for glycemic range parsing and logic in `test/glycemicRanges.test.js`, covering edge cases, CSV parsing, and parity with the blip renderer.
* Added integration tests to ensure the handler passes glycemic range query parameters through to the report logic unchanged.
* Updated report tests to match the new, more complete BG preference structure.

**Dependencies and versioning:**

* Bumped the package version to `1.7.8-WEB-4556-glycemic-ranges.1` and updated `@tidepool/viz` to a version supporting glycemic ranges. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L31-R31)

[WEB-4556]: https://tidepool.atlassian.net/browse/WEB-4556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ